### PR TITLE
Update Docker image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static@sha256:c6d5981545ce1406d33e61434c61e9452dad93ecd8397c41e89036ef977a88f4
+FROM gcr.io/distroless/static@sha256:d6fa9db9548b5772860fecddb11d84f9ebd7e0321c0cb3c02870402680cc315f
 LABEL maintainer "Bitnami <containers@bitnami.com>, Marko Mikulicic <mmikulicic@gmail.com>"
 
 ARG TARGETARCH


### PR DESCRIPTION
**Description of the change**

We updated distroless docker image to the latest version

**Benefits**

While running **trivy** tool on the actual image we noticed that there is a problem with tzdata (timezone database) library see Vutnerability IDs : 

1. DLA-2424-1
2. DLA-2509-1
3. DLA-2542-1
4. DLA-2797-1
5. DLA-2963-1

The problem is solved when we replace to the latest one

**Possible drawbacks**

- No drawbacks detected

**Applicable issues**

- No issues

**Additional information**

- All CI ckecks have passed
